### PR TITLE
Add kick plate displacement and its time derivatives as specified inputs to drive the kick

### DIFF
--- a/base_simulation.py
+++ b/base_simulation.py
@@ -38,10 +38,10 @@ def calc_fkp(t):
 def calc_kick_motion_constant_acc(t):
     """Returns the kick plate displacement, velocity, and acceleration assuming
     a constant acceleration and instaneous deceleration with a plate
-    displacement of 15 cm in 0.05 seconds. Constant acceleration is assumed
+    displacement of 15 cm in 0.1 seconds. Constant acceleration is assumed
     because the air cyclider force is mostly constant."""
 
-    stop = 0.05  # seconds
+    stop = 0.1  # seconds
     kick_displacement = 0.15  # meters
 
     # y(t) = m*t**2

--- a/base_simulation.py
+++ b/base_simulation.py
@@ -33,6 +33,25 @@ def calc_fkp(t):
         return 0.0
 
 
+def calc_kick_motion(t):
+    """Returns the lateral forced applied to the tire by the kick plate. The
+    force is modeled as a sinusoidal pulse."""
+    # TODO : return y, yd, ydd
+
+    start = 0.4  # seconds
+    stop = 0.6  # seconds
+    magnitude = 50.0  # m/s/s
+
+    period = stop - start
+    frequency = 1.0/period
+    omega = 2*np.pi*frequency  # rad/s
+
+    if start + period/2 < t < stop:
+        return magnitude/2.0*(1.0 - np.cos(omega*(t - start)))
+    else:
+        return 0.0
+
+
 def calc_steer_torque(t, x):
     """Simple LQR control based on linear Carvallo-Whipple model."""
 
@@ -88,7 +107,7 @@ def calc_inputs(t, x, p):
     Returns
     =======
     r : ndarray, shape(8,)
-        r = [T4, T6, T7, fkp, Fry, Ffy, Mrz, Mfz].
+        r = [T4, T6, T7, fkp, y, yd, ydd, Fry, Ffy, Mrz, Mfz].
 
     """
 
@@ -118,11 +137,14 @@ def calc_inputs(t, x, p):
     T4, T6, T7 = 0.0, 0.0, calc_steer_torque(t, x)
 
     # kick plate force
-    fkp = calc_fkp(t)
+    fkp = 0.0 #calc_fkp(t)
+
+    #
+    y, yd, ydd = calc_kick_motion(t)
 
     Mrz, Mfz = 0.0, 0.0
 
-    r = [T4, T6, T7, fkp, Fry, Ffy, Mrz, Mfz]
+    r = [T4, T6, T7, fkp, y, yd, ydd, Fry, Ffy, Mrz, Mfz]
 
     return r
 

--- a/base_simulation.py
+++ b/base_simulation.py
@@ -40,18 +40,18 @@ def calc_kick_motion(t):
 
     start = 0.4  # seconds
     stop = 0.6  # seconds
-    acc_magnitude = 50.0  # m/s/s
+    magnitude = 5.0  # m/s/s
 
     period = stop - start
     frequency = 1.0/period
     omega = 2*np.pi*frequency  # rad/s
 
-    magnitude = acc_magnitude/omega**2
-
-    if start + period/2 < t < stop:
-        y = magnitude/2.0*(1.0 - np.cos(omega*(t - start)))
-        yd = magnitude*omega*np.sin(omega*(t - start))/2
-        ydd = magnitude*omega**2*np.cos(omega*(start - t))/2
+    # TODO : figure out how to calculate the integration constants (-0.2 and
+    # -1.0)
+    if start < t < stop:
+        y = magnitude/2.0*(t**2/2.0 - (-np.cos(omega*(t - start))/omega)/omega) - 0.2
+        yd = magnitude/2.0*(t - np.sin(omega*(t - start))/omega) - 1.0
+        ydd = magnitude/2.0*(1.0 - np.cos(omega*(t - start)))
     else:
         y, yd, ydd = 0.0, 0.0, 0.0
 

--- a/base_simulation.py
+++ b/base_simulation.py
@@ -10,10 +10,12 @@ from simulate import (rr, rf, p_vals, p_arr, setup_initial_conditions, rhs,
                       calc_linear_tire_force, calc_nonlinear_tire_force,
                       eval_angles)
 
-from tire_data import TireCoefficients, SchwalbeT03_300kPa, SchwalbeT03_400kPa, SchwalbeT03_500kPa
+from tire_data import (TireCoefficients, SchwalbeT03_300kPa,
+                       SchwalbeT03_400kPa, SchwalbeT03_500kPa)
 
 # Define the tire to equip the bicycle
 tire = SchwalbeT03_500kPa
+
 
 def calc_fkp(t):
     """Returns the lateral forced applied to the tire by the kick plate. The
@@ -33,14 +35,39 @@ def calc_fkp(t):
         return 0.0
 
 
-def calc_kick_motion(t):
+def calc_kick_motion_constant_acc(t):
+    """Returns the kick plate displacement, velocity, and acceleration assuming
+    a constant acceleration and instaneous deceleration with a plate
+    displacement of 15 cm in 0.05 seconds. Constant acceleration is assumed
+    because the air cyclider force is mostly constant."""
+
+    stop = 0.05  # seconds
+    kick_displacement = 0.15  # meters
+
+    # y(t) = m*t**2
+    # y'(t) = 2*m*t
+    # y''(t) = 2*m
+    # y(stop) = d = m*stop**2 -> d = m*stop**2 -> m = d/(stop**2)
+
+    m = kick_displacement/(stop**2)
+    if 0.0 <= t < stop:
+        y, yd, ydd = m*t**2, 2.0*m*t, 2.0*m
+    elif t >= stop:
+        y, yd, ydd = kick_displacement, 0.0, 0.0
+    else:
+        y, yd, ydd = 0.0, 0.0, 0.0
+
+    return y, yd, ydd
+
+
+def calc_kick_motion_pulse_acc(t):
     """Returns the lateral forced applied to the tire by the kick plate. The
     force is modeled as a sinusoidal pulse."""
     # TODO : return y, yd, ydd
 
     start = 0.4  # seconds
     stop = 0.6  # seconds
-    magnitude = 5.0  # m/s/s
+    magnitude = 20.0  # m/s/s
 
     period = stop - start
     frequency = 1.0/period
@@ -49,9 +76,11 @@ def calc_kick_motion(t):
     # TODO : figure out how to calculate the integration constants (-0.2 and
     # -1.0)
     if start < t < stop:
-        y = magnitude/2.0*(t**2/2.0 - (-np.cos(omega*(t - start))/omega)/omega) - 0.2
-        yd = magnitude/2.0*(t - np.sin(omega*(t - start))/omega) - 1.0
+        y = magnitude/2.0*(t**2/2.0 - (-np.cos(omega*(t - start))/omega)/omega) - 0.8
+        yd = magnitude/2.0*(t - np.sin(omega*(t - start))/omega) - 4.0
         ydd = magnitude/2.0*(1.0 - np.cos(omega*(t - start)))
+    elif t >= stop:
+        y, yd, ydd = 1.0, 0.0, 0.0
     else:
         y, yd, ydd = 0.0, 0.0, 0.0
 
@@ -88,8 +117,6 @@ def calc_steer_torque(t, x):
     ku7 = 1.5876
 
     return -(kq4*q4 + kq7*q7 + ku4*u4 + ku7*u7)
-    #return 10.0*u4
-    #return 0.0
 
 
 def calc_inputs(t, x, p):
@@ -126,7 +153,7 @@ def calc_inputs(t, x, p):
     Ffz = -k_f*q12 - c_f*u12  # negative when in compression
 
     # plate motion
-    y, yd, ydd = calc_kick_motion(t)
+    y, yd, ydd = calc_kick_motion_constant_acc(t)
 
     c_af, c_ar = p[0], p[1]
     c_maf, c_mar, c_mpf = p[3], p[4], p[5]
@@ -201,7 +228,7 @@ duration = 6.0  # seconds
 res = simulate(duration, calc_inputs, initial_conditions, p_arr, fps=fps)
 
 plot_all(*res)
-plot_wheel_paths(res[1], res[-3], res[-2])
+plot_wheel_paths(res[1], res[-3], res[-2], res[-1][:, 4])
 plot_tire_curves()
 
 if __name__ == "__main__":

--- a/base_simulation.py
+++ b/base_simulation.py
@@ -39,9 +39,10 @@ def calc_kick_motion_constant_acc(t):
     """Returns the kick plate displacement, velocity, and acceleration assuming
     a constant acceleration and instaneous deceleration with a plate
     displacement of 15 cm in 0.1 seconds. Constant acceleration is assumed
-    because the air cyclider force is mostly constant."""
+    because the air cylinder force is approximately constant based on the
+    pressure sensor measurement."""
 
-    stop = 0.1  # seconds
+    stop = 0.05  # seconds
     kick_displacement = 0.15  # meters
 
     # y(t) = m*t**2
@@ -61,9 +62,8 @@ def calc_kick_motion_constant_acc(t):
 
 
 def calc_kick_motion_pulse_acc(t):
-    """Returns the lateral forced applied to the tire by the kick plate. The
-    force is modeled as a sinusoidal pulse."""
-    # TODO : return y, yd, ydd
+    """Returns the kick plate displacement, velocity, and acceleration assuming
+    a sinusoidal pulse acceleration."""
 
     start = 0.4  # seconds
     stop = 0.6  # seconds

--- a/base_simulation.py
+++ b/base_simulation.py
@@ -6,9 +6,9 @@ import matplotlib.pyplot as plt
 
 
 from simulate import (rr, rf, p_vals, p_arr, setup_initial_conditions, rhs,
-                      simulate, plot_all, plot_wheel_paths, plot_tire_curves,
-                      calc_linear_tire_force, calc_nonlinear_tire_force,
-                      eval_angles)
+                      simulate, plot_all, plot_kick_motion, plot_wheel_paths,
+                      plot_tire_curves, calc_linear_tire_force,
+                      calc_nonlinear_tire_force, eval_angles)
 
 from tire_data import (TireCoefficients, SchwalbeT03_300kPa,
                        SchwalbeT03_400kPa, SchwalbeT03_500kPa)
@@ -175,7 +175,9 @@ def calc_inputs(t, x, p):
     # kick plate force
     fkp = 0.0  # calc_fkp(t)
 
-    Mrz, Mfz = 0.0, 0.0
+    # NOTE : Self-aligning moment has a destabilizing effect, you can disable
+    # it by uncommenting the following line.
+    #Mrz, Mfz = 0.0, 0.0
 
     r = [T4, T6, T7, fkp, y, yd, ydd, Fry, Ffy, Mrz, Mfz]
 
@@ -228,6 +230,7 @@ duration = 6.0  # seconds
 res = simulate(duration, calc_inputs, initial_conditions, p_arr, fps=fps)
 
 plot_all(*res)
+plot_kick_motion(res[0], res[-1])
 plot_wheel_paths(res[1], res[-3], res[-2], res[-1][:, 4])
 plot_tire_curves()
 

--- a/base_simulation.py
+++ b/base_simulation.py
@@ -42,7 +42,7 @@ def calc_kick_motion_constant_acc(t):
     because the air cylinder force is approximately constant based on the
     pressure sensor measurement."""
 
-    stop = 0.05  # seconds
+    stop = 0.15  # seconds
     kick_displacement = 0.15  # meters
 
     # y(t) = m*t**2

--- a/nonlin_sym.py
+++ b/nonlin_sym.py
@@ -656,9 +656,9 @@ q10 = fn.pos_from(o).dot(N['2'])
 print('Lambdifying equations of motion.')
 eval_holonomic = sm.lambdify((q5, q4, q7, q11, q12, d1, d2, d3, r_tf, r_tr, rf,
                               rr), holonomic, cse=True)
-eval_dep_speeds = sm.lambdify([qs, u_ind, ps], [A_nh, -B_nh], cse=True)
+eval_dep_speeds = sm.lambdify([qs, u_ind, [y, yd], ps], [A_nh, -B_nh], cse=True)
 eval_dynamic = sm.lambdify([qs, us, fs, rs, ps], [A_all, b_all], cse=True)
-eval_angles = sm.lambdify((qs, us, ps), [alphar, alphaf, phir, phif], cse=True)
+eval_angles = sm.lambdify((qs, us, [y, yd], ps), [alphar, alphaf, phir, phif], cse=True)
 eval_front_contact = sm.lambdify((qs, ps), [q9, q10], cse=True)
 eval_equilibrium = sm.lambdify((qs, us, fs, rs, ps),
                                kane.forcing[:6, 0].col_join(sm.Matrix([holonomic])))

--- a/nonlin_sym.py
+++ b/nonlin_sym.py
@@ -78,6 +78,7 @@ print('Defining time varying symbols.')
 q1, q2, q3, q4 = mec.dynamicsymbols('q1, q2, q3, q4')
 q5, q6, q7, q8 = mec.dynamicsymbols('q5, q6, q7, q8')
 q11, q12 = mec.dynamicsymbols('q11, q12')
+y, yd, ydd = mec.dynamicsymbols('y, yd, ydd')
 
 # q's that will have kinematical differential equations
 qs = [
@@ -241,10 +242,14 @@ print('Defining position vectors.')
 # point fixed on the ground
 o = mec.Point('o')
 
+# point fixed on the kickplate (laterally moving ground)
+p = mec.Point('p')
+p.set_pos(o, y*N['2'])
+
 # rear wheel contact point, moves in ground plane, y is the kickplate lateral
 # location
 nd = mec.Point('nd')
-nd.set_pos(o, q1*N['1'] + q2*N['2'])
+nd.set_pos(p, q1*N['1'] + (q2 - y)*N['2'])
 
 # rear rim point
 dt = mec.Point('dt')
@@ -335,8 +340,11 @@ F.set_ang_vel(E, u8*E['2'])  # front wheel rate
 
 print('Defining linear velocities.')
 
-# rear wheel contact stays in ground plane
 o.set_vel(N, 0)
+
+p.set_vel(N, yd*N['2'])
+
+# rear wheel contact stays in ground plane
 nd.set_vel(N, u1*N['1'] + u2*N['2'])
 
 dt.set_vel(N, nd.vel(N) + u11*A['3'])
@@ -358,8 +366,9 @@ fn.set_vel(N, ft.pos_from(o).dt(N).xreplace(qdot_repl) - u12*A['3'])
 # Slip angle components
 # project the velocity vectors at the contact point onto each wheel's yaw
 # direction
-N_v_nd1 = nd.vel(N).dot(A['1'])
-N_v_nd2 = nd.vel(N).dot(A['2'])
+rear_slip_vel = nd.vel(N) - p.vel(N)
+N_v_nd1 = rear_slip_vel.dot(A['1'])
+N_v_nd2 = rear_slip_vel.dot(A['2'])
 # NOTE : Be careful on calculating these velocities for the slip angles. ft is
 # both the point fixed in the wheel (as shown in ft.v2pt_theory(fo, N, F) and
 # the point moving in the ground plane (as below). Probably should distinguish
@@ -385,7 +394,7 @@ print('Defining nonholonomic constraints.')
 
 nonholonomic = [
     # no rear longitudinal slip
-    sm.trigsimp(dn.vel(N).dot(A['1'])),
+    sm.trigsimp((dn.vel(N) - p.vel(N)).dot(A['1'])),
     # no front longitudinal slip
     ft.vel(N).dot(g1_hat),
     # front contact cannot move vertically wrt ground
@@ -538,7 +547,7 @@ ps = (
     s_zf,  # 42
     s_zr,  # 43
 )
-rs = (T4, T6, T7, Fkp)
+rs = (T4, T6, T7, Fkp, y, yd, ydd)
 holon = (holonomic,)
 nonho = tuple(nonholonomic)
 
@@ -617,6 +626,7 @@ for i in range(mass_matrix.shape[0]):
     forcing[new_order[i], 0] = forcing_orig[i, 0]
     for j in range(mass_matrix.shape[1]):
         mass_matrix[new_order[i], new_order[j]] = kane.mass_matrix[i, j]
+forcing = forcing.xreplace({yd.diff(t): ydd})
 
 num_udots = mass_matrix.shape[0]
 row1 = mass_matrix.row_join(sm.zeros(num_udots, 4))

--- a/simple_kick_plate_simulation.py
+++ b/simple_kick_plate_simulation.py
@@ -1,0 +1,79 @@
+"""This is a simple single mass simulation to try to understand how the
+kickplate may move when hit with the force from the pressurized cylinder. Most
+of the constants are best guesses, but the basic acceleration profile can be
+seen and compared with the accelerometer measurement taken on the kickplate.
+
+"""
+
+import numpy as np
+import matplotlib.pyplot as plt
+from scipy.integrate import solve_ivp
+
+m = 25.0  # mass of plate + some portion of bike/rider [kg]
+mu = 1.2  # coefficient of friction of plate with rails
+g = 9.81  # acceleration due to gravity [m/s/s]
+k = 10000000.0  # stopper Hunt/Crossley model stiffness
+c = 1000.0  # stopper Hunt/Crossley model damping
+x_wall = 0.15  # plate travel distance [m]
+
+
+def rhs(t, s):
+
+    x = s[0]
+    v = s[1]
+
+    # constant piston force
+    if t < 0.05:
+        Fp = 1500.0  # N
+    else:
+        Fp = 0.0
+
+    # stopper collision force
+    if x > 0.15:
+        xterm = (x - x_wall)**(3.0/2.0)
+        Fw = k*xterm + c*v*xterm
+    else:
+        Fw = 0.0
+
+    # friction force
+    if np.abs(v) < 0.01:
+        Ff = 0.0
+    else:
+        Ff = np.sign(v)*mu*m*g
+
+    dxdt = v
+    dvdt = (-Ff - Fw + Fp)/m
+
+    return dxdt, dvdt, Fp, Fw
+
+
+t0, tf, s0 = 0.0, 0.3, np.array([0.0, 0.0])
+t = np.linspace(t0, tf, num=1001)
+
+sol = solve_ivp(lambda t, x: rhs(t, x)[0:2],
+                (t0, tf), s0, t_eval=t) #, method='LSODA')
+
+a, Fp, Fw = [], [], []
+for ti, si in zip(sol.t, sol.y.T):
+    _, ai, Fpi, Fwi = rhs(ti, si)
+    a.append(ai)
+    Fp.append(Fpi)
+    Fw.append(Fwi)
+a = np.array(a)
+Fp = np.array(Fp)
+Fw = np.array(Fw)
+
+fig, axes = plt.subplots(5, 1, sharex=True)
+
+axes[0].plot(sol.t, Fp)
+axes[0].set_ylabel(r'$F_p$')
+axes[1].plot(sol.t, Fw)
+axes[1].set_ylabel(r'$F_w$')
+axes[2].plot(sol.t, sol.y[0])
+axes[2].set_ylabel(r'$x$')
+axes[3].plot(sol.t, sol.y[1])
+axes[3].set_ylabel(r'$v$')
+axes[4].plot(sol.t, a)
+axes[4].set_ylabel(r'$a$')
+
+plt.show()

--- a/simulate.py
+++ b/simulate.py
@@ -30,7 +30,7 @@ def rhs(t, x, r_func, p):
                                 Fry, Ffy, Mrz, Mfz].
     r_func : function
         Function of the form ``r = f(t, x, p)``. Returns all specified inputs
-        where: r = [T4, T6, T7, fkp, Fry, Ffy, Mrz, Mfz].
+        where: r = [T4, T6, T7, fkp, y, yd, ydd, Fry, Ffy, Mrz, Mfz].
     p : array_like, shape(44,)
         Constant values.
         [c_af, c_ar, c_f, c_maf, c_mar, c_mpf, c_mpr, c_pf, c_pr, c_r, d1, d2,
@@ -73,7 +73,7 @@ def equilibrium_eq(q, p):
     #u = np.ones(10)*1e-13  # divide by zeros if u is simple all zeros
     u = np.zeros(10)
     f = np.zeros(4)  # Fry, Ffy, Mrz, Mfz
-    r = np.zeros(8)  # T4, T6, T7, Fkp, Fry_, Ffy_, Mrz_, Mfz_
+    r = np.zeros(11)  # T4, T6, T7, Fkp, y, yd, ydd, Fry_, Ffy_, Mrz_, Mfz_
 
     def zeros(x):
         """
@@ -121,7 +121,7 @@ def calc_linear_tire_force(alpha, phi, Fz, c_a, c_p, c_ma, c_mp):
     return Fy, Mz
 
 
-def calc_nonlinear_tire_force(alpha, phi, Fz, tire: TireCoefficients):
+def calc_nonlinear_tire_force(alpha, phi, Fz, tire_data):
     """Returns the lateral force and self-aligning moment at the contact patch
     acting on the tire.
 
@@ -133,6 +133,8 @@ def calc_nonlinear_tire_force(alpha, phi, Fz, tire: TireCoefficients):
         Camber angle in radians, positive is roll to the right.
     Fz : float
         Normal force in Newtons, negative in compression.
+    tire_data : TireCoefficients
+        Tire model constants.
 
     Returns
     =======
@@ -147,9 +149,9 @@ def calc_nonlinear_tire_force(alpha, phi, Fz, tire: TireCoefficients):
     Fz = -Fz/1000.00  # MUST be in [kN]
     alpha = np.rad2deg(alpha)    # angles input in [deg]
     phi = np.rad2deg(phi)        # angles input in [deg]
-    
-    opt_Pac_fy = tire.Fy_coef
-    opt_Pac_Mz = tire.Mz_coef
+
+    opt_Pac_fy = tire_data.Fy_coef
+    opt_Pac_Mz = tire_data.Mz_coef
 
     C_mz = opt_Pac_Mz[0]  # Shape factor
     D_mz = (opt_Pac_Mz[1]*Fz**2 + opt_Pac_Mz[2]*Fz)  # Peak factor
@@ -210,7 +212,7 @@ p_vals = {
     d2: 0.4338396131640938,
     d3: 0.0705000000001252,
     g: 9.81,
-    
+
     ic11 : 12.242077,   # --START-- Parameters for Gabriele (635 N)
     ic22 : 14.951251,
     ic31 : 3.214818,
@@ -256,7 +258,7 @@ p_vals = {
     # mf : 1.550000,
     # rr : 0.332528,
     # rf : 0.335573,  # --END-- Parameters for Timo (701 N)
-    
+
     # ic11: 11.519805885486146,      # --- Old parameters (original ones from Jason)
     # ic22: 12.2177848012,
     # ic31: 1.57915608541552,
@@ -500,7 +502,7 @@ def plot_tire_curves():
 
     fig, axes = plt.subplots(2, 2, layout='constrained')
 
-    # Update "tire" to plot the current tire characteristics you are using for simulations 
+    # Update "tire" to plot the current tire characteristics you are using for simulations
     for Fz, color in zip(normal_forces, colors):
         Fys, Mzs = [], []
         Fys_lin, Mzs_lin = [], []

--- a/simulate.py
+++ b/simulate.py
@@ -4,7 +4,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from nonlin_sym import *
-from tire_data import TireCoefficients, SchwalbeT03_300kPa, SchwalbeT03_400kPa, SchwalbeT03_500kPa
+from tire_data import (TireCoefficients, SchwalbeT03_300kPa,
+                       SchwalbeT03_400kPa, SchwalbeT03_500kPa)
 ##########################
 # Check evaluation of EoMs
 ##########################
@@ -196,7 +197,6 @@ def calc_nonlinear_tire_force(alpha, phi, Fz, tire_data):
 
 # batavus browser with Jason sitting on it, tire parameters from
 # Andrew/Gabriele
-# TODO Create new dataclass to handle different riders' parameters
 p_vals = {
     c_af: 11.46,  # estimates from Andrew's dissertation (done by him)
     c_ar: 11.46,
@@ -212,85 +212,61 @@ p_vals = {
     d2: 0.4338396131640938,
     d3: 0.0705000000001252,
     g: 9.81,
-
-    ic11 : 12.242077,   # --START-- Parameters for Gabriele (635 N)
-    ic22 : 14.951251,
-    ic31 : 3.214818,
-    ic33 : 4.493685,
-    id11 : 0.070096,
-    id22 : 0.129342,
-    ie11 : 0.374921,
-    ie22 : 0.339925,
-    ie31 : -0.002581,
-    ie33 : 0.072061,
-    if11 : 0.052448,
-    if22 : 0.098372,
-    l1 : 0.526720,
-    l2 : -0.537772,
-    l3 : -0.030119,
-    l4 : -0.694391,
-    mc : 83.900000,
-    md : 4.900000,
-    me : 5.400000,
-    mf : 1.550000,
-    rr : 0.332528,
-    rf : 0.335573,  # --END-- Parameters for Gabriele (635 N)
-
-    # ic11 : 14.338830,   # --START-- Parameters for Timo (701 N)
-    # ic22 : 17.115790,
-    # ic31 : 3.610619,
-    # ic33 : 4.976662,
-    # id11 : 0.070096,
-    # id22 : 0.129342,
-    # ie11 : 0.374921,
-    # ie22 : 0.339925,
-    # ie31 : -0.002581,
-    # ie33 : 0.072061,
-    # if11 : 0.052448,
-    # if22 : 0.098372,
-    # l1 : 0.542381,
-    # l2 : -0.556788,
-    # l3 : -0.030119,
-    # l4 : -0.694391,
-    # mc : 92.900000,
-    # md : 4.900000,
-    # me : 5.400000,
-    # mf : 1.550000,
-    # rr : 0.332528,
-    # rf : 0.335573,  # --END-- Parameters for Timo (701 N)
-
-    # ic11: 11.519805885486146,      # --- Old parameters (original ones from Jason)
-    # ic22: 12.2177848012,
-    # ic31: 1.57915608541552,
-    # ic33: 2.959474124693854,
-    # id11: 0.0883819364527,
-    # id22: 0.152467620286,
-    # ie11: 0.2811355367159554,
-    # ie22: 0.246138810935,
-    # ie31: 0.0063377219110826045,
-    # ie33: 0.06782113764394461,
-    # if11: 0.0904106601579,
-    # if22: 0.149389340425,
-    # l1: 0.5384415640161426,
-    # l2: -0.531720230353059,
-    # l3: -0.07654646159268344,
-    # l4: -0.47166687226492093,
-    # mc: 81.86,
-    # md: 3.11,
-    # me: 3.22,
-    # mf: 2.02,
-    # rf: 0.34352982332,
-    # rr: 0.340958858855,   # --- Old parameters (original ones from Jason)
+    ic11: 12.242077,   # --START-- Parameters for Gabriele (635 N)
+    ic22: 14.951251,
+    ic31: 3.214818,
+    ic33: 4.493685,
+    id11: 0.070096,
+    id22: 0.129342,
+    ie11: 0.374921,
+    ie22: 0.339925,
+    ie31: -0.002581,
+    ie33: 0.072061,
+    if11: 0.052448,
+    if22: 0.098372,
     k_f: 133000.0,  # [pressure 3 bar k_f:80000] [pressure 4 bar k_f:106000] [pressure 5 bar k_f:133000]. From G. Dell'Orto 2023 (EJM/A Solids)
     k_r: 133000.0,  # same as k_f [N/m]
+    l1: 0.526720,
+    l2: -0.537772,
+    l3: -0.030119,
+    l4: -0.694391,
+    mc: 83.900000,
+    md: 4.900000,
+    me: 5.400000,
+    mf: 1.550000,
     r_tf: 0.01,
     r_tr: 0.01,
+    rf: 0.335573,  # --END-- Parameters for Gabriele (635 N)
+    rr: 0.332528,
     s_yf: 0.175,  # Andrew's estimates from his dissertation data
     s_yr: 0.175,
     s_zf: 0.175,
     s_zr: 0.175,
 }
 p_arr = np.array([p_vals[pi] for pi in ps])
+
+# ic11 : 14.338830,   # --START-- Parameters for Timo (701 N)
+# ic22 : 17.115790,
+# ic31 : 3.610619,
+# ic33 : 4.976662,
+# id11 : 0.070096,
+# id22 : 0.129342,
+# ie11 : 0.374921,
+# ie22 : 0.339925,
+# ie31 : -0.002581,
+# ie33 : 0.072061,
+# if11 : 0.052448,
+# if22 : 0.098372,
+# l1 : 0.542381,
+# l2 : -0.556788,
+# l3 : -0.030119,
+# l4 : -0.694391,
+# mc : 92.900000,
+# md : 4.900000,
+# me : 5.400000,
+# mf : 1.550000,
+# rf : 0.335573,  # --END-- Parameters for Timo (701 N)
+# rr : 0.332528,
 
 
 def setup_initial_conditions(q_vals, u_vals, f_vals, p_arr):
@@ -523,7 +499,8 @@ def plot_tire_curves():
 
     fig, axes = plt.subplots(2, 2, layout='constrained')
 
-    # Update "tire" to plot the current tire characteristics you are using for simulations
+    # Update "tire" to plot the current tire characteristics you are using for
+    # simulations
     for Fz, color in zip(normal_forces, colors):
         Fys, Mzs = [], []
         Fys_lin, Mzs_lin = [], []

--- a/simulate.py
+++ b/simulate.py
@@ -472,12 +472,17 @@ def plot_all(times, q_traj, u_traj, slip_traj, f_traj, fz_traj, con_traj,
     axes[14, 1].set_ylabel('phif\n[deg]')
 
     axes[-1, 0].plot(times, r_traj[:, -1])
-    axes[-1, 0].set_ylabel('$F_{kp}$\n[N]')
+    axes[-1, 0].set_ylabel('$\ddot{y}$\n[m/s/s]')
     axes[-1, 0].set_xlabel('Time [s]')
     axes[-1, 1].plot(times, con_traj)
     axes[-1, 1].set_ylabel('constraint\n[m]')
     axes[-1, 1].set_xlabel('Time [s]')
     plt.tight_layout()
+
+    fig2, ax2 = plt.subplots(3, 1, sharex=True)
+    ax2[0].plot(times, r_traj[:, -1])
+    ax2[1].plot(times, r_traj[:, -2])
+    ax2[2].plot(times, r_traj[:, -3])
 
     return axes
 

--- a/simulate.py
+++ b/simulate.py
@@ -430,7 +430,7 @@ def plot_all(times, q_traj, u_traj, slip_traj, f_traj, fz_traj, con_traj,
              q9_traj, q10_traj, r_traj):
 
     deg = [False, False, True, True, True, True, True, True, False, False]
-    fig, axes = plt.subplots(16, 2, sharex=True)
+    fig, axes = plt.subplots(16, 2, sharex=True, layout='constrained')
     fig.set_size_inches(8, 10)
     # fills right 10 rows
     for i, (ax, traj, s, degi) in enumerate(zip(axes[:, 0], q_traj.T, qs, deg)):
@@ -478,21 +478,35 @@ def plot_all(times, q_traj, u_traj, slip_traj, f_traj, fz_traj, con_traj,
     axes[-1, 1].plot(times, con_traj)
     axes[-1, 1].set_ylabel('constraint\n[m]')
     axes[-1, 1].set_xlabel('Time [s]')
-    plt.tight_layout()
 
-    fig2, ax2 = plt.subplots(3, 1, sharex=True)
-    ax2[0].plot(times, r_traj[:, -1])
-    ax2[1].plot(times, r_traj[:, -2])
-    ax2[2].plot(times, r_traj[:, -3])
+
+def plot_kick_motion(times, r_traj):
+
+    fig, axes = plt.subplots(3, 1, sharex=True, layout='constrained')
+    axes[0].plot(times, r_traj[:, -1])
+    axes[0].set_ylabel(r'$\ddot{y}$ [m/s/s]')
+    axes[1].plot(times, r_traj[:, -2])
+    axes[1].set_ylabel(r'$\dot{y}$ [m/s]')
+    axes[2].plot(times, r_traj[:, -3])
+    axes[2].set_ylabel(r'$y$ [m]')
+    axes[2].set_xlabel('Time [s]')
 
     return axes
 
 
 def plot_wheel_paths(q_traj, q9_traj, q10_traj, kick_displacement):
     fig, ax = plt.subplots(1, 1)
-    ax.plot(q_traj[:, 0], q_traj[:, 1] - kick_displacement)
-    ax.plot(q9_traj, q10_traj)
+    ax.plot(q_traj[:, 0], q_traj[:, 1], label='Rear Wheel Contact')
+    ax.plot(q9_traj, q10_traj, label='Front Wheel Contact')
+    # NOTE : I plot the kickplate displacement vs rear wheel longitudinal
+    # motion for comparison purposes.
+    ax.plot(q_traj[:, 0], kick_displacement, label='Kick Plate Displacement')
     ax.set_aspect('equal')
+    ax.set_xlabel(r'$\hat{n}_1$')
+    ax.set_ylabel(r'$\hat{n}_2$')
+    ax.invert_yaxis()
+    ax.grid()
+    ax.legend()
     return ax
 
 

--- a/simulate.py
+++ b/simulate.py
@@ -356,6 +356,7 @@ def setup_initial_conditions(q_vals, u_vals, f_vals, p_arr):
     print('Independent generalized speeds:', u_vals[[2, 3, 5, 6, 7, 8, 9]])
     A_nh_vals, B_nh_vals = eval_dep_speeds(q_vals,
                                            u_vals[[2, 3, 5, 6, 7, 8, 9]],
+                                           [0.0, 0.0],  # y, yd
                                            p_arr)
     res = np.linalg.solve(A_nh_vals, B_nh_vals.squeeze())
     print('res', res)
@@ -411,14 +412,14 @@ def simulate(dur, calc_inputs, x0, p, fps=60):
     slip_traj = np.zeros((len(times), 4))
     q9_traj = np.zeros_like(times)
     q10_traj = np.zeros_like(times)
-    r_traj = np.zeros((len(times), 4))
+    r_traj = np.zeros((len(times), 7))
     for i, (ti, qi, ui, fi) in enumerate(zip(times, q_traj, u_traj, f_traj)):
         statei = np.hstack((qi, ui, fi))
+        r_traj[i] = calc_inputs(ti, statei, p)[:7]
         fz_traj[i, :] = np.array([-p[27]*qi[8] - p[9]*ui[8],
                                   -p[26]*qi[9] - p[2]*ui[9]])
-        slip_traj[i, :] = eval_angles(qi, ui, p)
+        slip_traj[i, :] = eval_angles(qi, ui, r_traj[i, 3:5], p)
         q9_traj[i], q10_traj[i] = eval_front_contact(qi, p)
-        r_traj[i] = calc_inputs(ti, statei, p)[:4]
 
     return (times, q_traj, u_traj, slip_traj, f_traj, fz_traj, con_traj,
             q9_traj, q10_traj, r_traj)

--- a/simulate.py
+++ b/simulate.py
@@ -281,10 +281,11 @@ p_vals = {
     # mf: 2.02,
     # rf: 0.34352982332,
     # rr: 0.340958858855,   # --- Old parameters (original ones from Jason)
-    k_f: 120000.0,  # ~ twice the stiffness of a 1.25" tire from Rothhamel 2024
-    k_r: 120000.0,  # ~ twice the stiffness of a 1.25" tire from Rothhamel 2024
+    k_f: 133000.0,  # [pressure 3 bar k_f:80000] [pressure 4 bar k_f:106000] [pressure 5 bar k_f:133000]. From G. Dell'Orto 2023 (EJM/A Solids)
+    k_r: 133000.0,  # same as k_f [N/m]
     r_tf: 0.01,
-    r_tr: 0.01,s_yf: 0.175,  # Andrew's estimates from his dissertation data
+    r_tr: 0.01,
+    s_yf: 0.175,  # Andrew's estimates from his dissertation data
     s_yr: 0.175,
     s_zf: 0.175,
     s_zr: 0.175,

--- a/simulate.py
+++ b/simulate.py
@@ -488,9 +488,9 @@ def plot_all(times, q_traj, u_traj, slip_traj, f_traj, fz_traj, con_traj,
     return axes
 
 
-def plot_wheel_paths(q_traj, q9_traj, q10_traj):
+def plot_wheel_paths(q_traj, q9_traj, q10_traj, kick_displacement):
     fig, ax = plt.subplots(1, 1)
-    ax.plot(q_traj[:, 0], q_traj[:, 1])
+    ax.plot(q_traj[:, 0], q_traj[:, 1] - kick_displacement)
     ax.plot(q9_traj, q10_traj)
     ax.set_aspect('equal')
     return ax

--- a/visualize.ipynb
+++ b/visualize.ipynb
@@ -17,7 +17,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "scene.display_jupyter(axes_arrow_length=20.0)"
+    "scene.display_jupyter(window_size=(1800, 600), axes_arrow_length=20.0)"
    ]
   }
  ],
@@ -37,7 +37,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,

--- a/viz.py
+++ b/viz.py
@@ -1,5 +1,5 @@
 import numpy as np
-from pydy.viz import (Sphere, Cylinder, VisualizationFrame, Scene,
+from pydy.viz import (Sphere, Cylinder, Box, VisualizationFrame, Scene,
                       PerspectiveCamera)
 from simulate import *
 from base_simulation import *
@@ -34,15 +34,23 @@ eo_sphere = Sphere(radius=0.05, color='blue', name='rear frame eo')
 co_frame = VisualizationFrame(C, co, co_sphere)
 eo_frame = VisualizationFrame(E, eo, eo_sphere)
 
+plate_box = Box(width=1.0, height=1.0, depth=0.01, color='red', name='grey')
+plate_frame = VisualizationFrame(N, p.locatenew('below', 0.005*N['3']),
+                                 plate_box)
+
 # TODO : Moving camera does not seem to work.
 camera_loc = o.locatenew('p_camera', -10*N.z + q1*N.x)
 camera = PerspectiveCamera('camera', N, camera_loc)
 
 scene = Scene(N, o) #, cameras=[camera])
 scene.visualization_frames = [front_wheel_vframe, rear_wheel_vframe, d1_frame,
-                              d2_frame, d3_frame, co_frame, eo_frame]
+                              d2_frame, d3_frame, co_frame, eo_frame,
+                              plate_frame]
 
 scene.times = times
 scene.constants = p_vals
-scene.states_symbols = qs + us
-scene.states_trajectories = np.hstack((q_traj, u_traj))
+# Scene does not seem to accept specified values. In our case we need to pass
+# in y (kickplate displacement) for the visualization. The following is a hack
+# to swap one of the u's with y.
+scene.states_symbols = qs + us[0:9] + [rs[4]]
+scene.states_trajectories = np.hstack((q_traj, u_traj[:, 0:9], r_traj[:, 4:5]))


### PR DESCRIPTION
This adopts the model to include a lateral displacement of the kick plate, which can be used to drive the perturbation input to the model.

TODO:
- [x] Make the icsc 2023 simulation work with the new model.