### PR TITLE
Add a symmeplot visualziation.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Description
 ===========
 
-https://github.com/user-attachments/assets/71bbadf5-80d3-4f66-bf41-2daf0c47d846
+https://github.com/user-attachments/assets/763f898f-44b9-431b-bffe-0263762950e4
 
 Dynamic model of a bicycle that includes both a nonlinear and linear tire
 model. The model includes lateral forces, self-aligning moments, relaxation

--- a/base_simulation.py
+++ b/base_simulation.py
@@ -131,14 +131,13 @@ print(initial_conditions)
 print('Test rhs with initial conditions and correct constants:')
 print(rhs(0.0, initial_conditions, calc_inputs, p_arr))
 
-fps = 400  # frames per second
+fps = 60  # frames per second
 duration = 6.0  # seconds
 res = simulate(duration, calc_inputs, initial_conditions, p_arr, fps=fps)
 
-plot_all(*res)
-plot_kick_motion(res[0], res[-1])
-plot_wheel_paths(res[1], res[-3], res[-2], res[-1][:, 4])
-plot_tire_curves(p_vals)
-
 if __name__ == "__main__":
+    plot_all(*res)
+    plot_kick_motion(res[0], res[-1])
+    plot_wheel_paths(res[1], res[-3], res[-2], res[-1][:, 4])
+    plot_tire_curves(p_vals)
     plt.show()

--- a/bicycle-kickplate-model-env.yml
+++ b/bicycle-kickplate-model-env.yml
@@ -11,5 +11,5 @@ dependencies:
   - python ==3.12.4
   - pythreejs ==2.4.2
   - scipy ==1.14.1
-  - symmeplot
+  - symmeplot ==0.2.1
   - sympy ==1.13.3

--- a/bicycle-kickplate-model-env.yml
+++ b/bicycle-kickplate-model-env.yml
@@ -11,4 +11,5 @@ dependencies:
   - python ==3.12.4
   - pythreejs ==2.4.2
   - scipy ==1.14.1
+  - symmeplot
   - sympy ==1.13.3

--- a/model.py
+++ b/model.py
@@ -88,8 +88,12 @@ A.orient(N, 'Axis', (q3, N['3']))
 B.orient(A, 'Axis', (q4, A['1']))
 # rear frame pitch
 C.orient(B, 'Axis', (q5, B['2']))
+# rear wheel rotation
+D.orient(C, 'Axis', (q6, C['2']))
 # front frame steer
 E.orient(C, 'Axis', (q7, C['3']))
+# front wheel rotation
+F.orient(E, 'Axis', (q8, E['2']))
 
 # create a front "yaw" frame that is equivalent to the A frame for the rear
 # wheel.

--- a/mplviz.py
+++ b/mplviz.py
@@ -1,0 +1,39 @@
+import matplotlib.pyplot as plt
+
+from symbols import rr, rf, y, qs, ps
+from model import N, o, rear_wheel, front_wheel
+from symmeplot.matplotlib import Scene3D
+from base_simulation import *
+
+(times, q_traj, u_traj, slip_traj, f_traj, fz_traj, con_traj, q9_traj,
+ q10_traj, r_traj) = res
+
+scene = Scene3D(N, o) #, scale=0.5)
+rear_wheel_plot = scene.add_body(rear_wheel)
+rear_wheel_plot.attach_circle(
+    rear_wheel.masscenter,
+    rr,
+    rear_wheel.frame.y,
+    facecolor="red", edgecolor="k")
+
+front_wheel_plot = scene.add_body(front_wheel)
+front_wheel_plot.attach_circle(
+    front_wheel.masscenter,
+    rf,
+    front_wheel.frame.y,
+    facecolor="red", edgecolor="k")
+
+#scene.add_body(rear_frame_body)
+#scene.add_line(some_points_describing_the_rear_frame)
+#
+#scene.add_body(front_frame_body)
+#scene.add_line(some_points_describing_the_front_frame)
+
+# For a single state plot:
+scene.lambdify_system(qs + [y] + list(ps))
+scene.evaluate_system(*np.hstack((q_traj[0, :], r_traj[0, 4:5], p_arr)))
+
+plt.show()
+
+#ani = scene.animate(lambda q: (q,), frames=np.linspace(0, 2 * np.pi, 60))
+#ani.save("animation.gif", fps=30)

--- a/mplviz.py
+++ b/mplviz.py
@@ -1,43 +1,52 @@
 import numpy as np
 import matplotlib.pyplot as plt
 
-from symbols import rr, rf, y, qs, ps
-from model import N, o, p, rear_wheel, front_wheel
+from symbols import rr, rf, y, qs, ps, d1, d2, d3
+from model import N, C, E, o, p, do, fo, nd, rear_wheel, front_wheel
 from symmeplot.matplotlib import Scene3D
-from base_simulation import p_arr, res
+from base_simulation import p_arr, res, fps
 
 (times, q_traj, u_traj, slip_traj, f_traj, fz_traj, con_traj, q9_traj,
  q10_traj, r_traj) = res
 
-scene = Scene3D(N, o, scale=0.5)
+fig, ax = plt.subplots(subplot_kw={'projection': '3d'})
+
+scene = Scene3D(N,
+                o.locatenew('e', nd.pos_from(o).dot(N.x)*N.x),
+                ax=ax, scale=2.0)
 
 scene.add_frame(N, p)  # kick plate
+scene.add_line([o, o.locatenew('pp', 0.5*N.x)])  # reference
+scene.add_line([p, p.locatenew('pp', 0.5*N.x)])  # kick plate
 
 rear_wheel_plot = scene.add_body(rear_wheel)
 rear_wheel_plot.attach_circle(
     rear_wheel.masscenter,
     rr,
     rear_wheel.frame.y,
-    facecolor="red", edgecolor="k")
+    facecolor="none", edgecolor="k")
 
 front_wheel_plot = scene.add_body(front_wheel)
 front_wheel_plot.attach_circle(
     front_wheel.masscenter,
     rf,
     front_wheel.frame.y,
-    facecolor="red", edgecolor="k")
+    facecolor="none", edgecolor="k")
 
-#scene.add_body(rear_frame_body)
-#scene.add_line(some_points_describing_the_rear_frame)
-#
-#scene.add_body(front_frame_body)
-#scene.add_line(some_points_describing_the_front_frame)
+scene.add_line([do,
+                do.locatenew('d1_half', d1*C.x),
+                fo.locatenew('d2_half', -d3*E.x - d2*E.z),
+                fo,
+                fo.locatenew('d3_half', -d3*E.x)])
 
-# For a single state plot:
 scene.lambdify_system(qs + [y] + list(ps))
 scene.evaluate_system(*np.hstack((q_traj[0, :], r_traj[0, 4:5], p_arr)))
 
-plt.show()
+scene.plot()
 
-#ani = scene.animate(lambda q: (q,), frames=np.linspace(0, 2 * np.pi, 60))
-#ani.save("animation.gif", fps=30)
+ax.invert_zaxis()
+
+slow_factor = 3  # int
+ani = scene.animate(lambda i: np.hstack((q_traj[i, :], r_traj[i, 4:5], p_arr)),
+                    frames=len(times), interval=slow_factor/fps*1000)
+ani.save("animation.gif", fps=fps//slow_factor)

--- a/mplviz.py
+++ b/mplviz.py
@@ -1,14 +1,18 @@
+import numpy as np
 import matplotlib.pyplot as plt
 
 from symbols import rr, rf, y, qs, ps
-from model import N, o, rear_wheel, front_wheel
+from model import N, o, p, rear_wheel, front_wheel
 from symmeplot.matplotlib import Scene3D
-from base_simulation import *
+from base_simulation import p_arr, res
 
 (times, q_traj, u_traj, slip_traj, f_traj, fz_traj, con_traj, q9_traj,
  q10_traj, r_traj) = res
 
-scene = Scene3D(N, o) #, scale=0.5)
+scene = Scene3D(N, o, scale=0.5)
+
+scene.add_frame(N, p)  # kick plate
+
 rear_wheel_plot = scene.add_body(rear_wheel)
 rear_wheel_plot.attach_circle(
     rear_wheel.masscenter,


### PR DESCRIPTION
Fixes #24

How to run:

```
conda activate bicycle-kickplate-model
python mplviz.py
```

Using:

```
(bicycle-kickplate-model) moorepants@nandi:bicycle-kickplate-model(symmeplot)$ conda list symmeplot
# packages in environment at /home/moorepants/miniconda/envs/bicycle-kickplate-model:
#
# Name                    Version                   Build  Channel
symmeplot                 0.2.1              pyhd8ed1ab_1    conda-forge
(bicycle-kickplate-model) moorepants@nandi:bicycle-kickplate-model(symmeplot)$ conda list matplotlib
# packages in environment at /home/moorepants/miniconda/envs/bicycle-kickplate-model:
#
# Name                    Version                   Build  Channel
matplotlib                3.9.2           py311h38be061_1    conda-forge
matplotlib-base           3.9.2           py311h2b939e6_1    conda-forge
matplotlib-inline         0.1.7              pyhd8ed1ab_0    conda-forge
```